### PR TITLE
Installation in Visual Studio 2019 Preview

### DIFF
--- a/ReAttach/source.extension.vsixmanifest
+++ b/ReAttach/source.extension.vsixmanifest
@@ -12,14 +12,13 @@
 		<Tags>attach, debug</Tags>
 	</Metadata>
 	<Installation>
-		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,15.0]" />
+		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,17.0)" />
 	</Installation>
 	<Dependencies>
 		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-		<Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0]" />
 	</Dependencies>
 	<Prerequisites>
-		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
 	</Prerequisites>
 	<Assets>
 		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Following the blog post https://blogs.msdn.microsoft.com/visualstudio/2018/09/26/how-to-upgrade-extensions-to-support-visual-studio-2019/ this makes ReAttach compatible with Visual Studio 2019 Preview