### PR TITLE
Check LastBuildInfo to determine if any projects failed to build.

### DIFF
--- a/ReAttach/Services/ReAttachUi.cs
+++ b/ReAttach/Services/ReAttachUi.cs
@@ -108,38 +108,45 @@ namespace ReAttach
             if (target == null)
                 return;
 
+            bool? buildSuccessful = null;
             if (_options.BuildBeforeReAttach)
-                TryBuildSolution();
-
-            if (!EnsureDebuggerService())
             {
-                ReAttachUtils.ShowError("ReAttach failed.", "Unable to obtain ref to debugger service.");
-                return;
+                buildSuccessful = TryBuildSolution();
             }
 
-            var result = _debugger.ReAttach(target);
-            if (result == ReAttachResult.NotStarted)
+            //only ReAttach if the build has run before and was successful
+            if ((buildSuccessful ?? false) == true)
             {
-                var dialog = new WaitingDialog(_debugger, target);
-                dialog.ShowModal();
-                result = dialog.Result;
-            }
+                if (!EnsureDebuggerService())
+                {
+                    ReAttachUtils.ShowError("ReAttach failed.", "Unable to obtain ref to debugger service.");
+                    return;
+                }
 
-            switch (result)
-            {
-                case ReAttachResult.Success:
-                    break;
-                case ReAttachResult.ElevationRequired:
-                    ReAttachUtils.ShowElevationDialog();
-                    break;
-                case ReAttachResult.NotStarted:
-                    ReAttachUtils.ShowError("ReAttach failed.", "Process not started.");
-                    break;
-                case ReAttachResult.Cancelled:
-                    break;
-                case ReAttachResult.Failed:
-                    ReAttachUtils.ShowError("ReAttach failed.", "Failed reattaching to process.");
-                    break;
+                var result = _debugger.ReAttach(target);
+                if (result == ReAttachResult.NotStarted)
+                {
+                    var dialog = new WaitingDialog(_debugger, target);
+                    dialog.ShowModal();
+                    result = dialog.Result;
+                }
+
+                switch (result)
+                {
+                    case ReAttachResult.Success:
+                        break;
+                    case ReAttachResult.ElevationRequired:
+                        ReAttachUtils.ShowElevationDialog();
+                        break;
+                    case ReAttachResult.NotStarted:
+                        ReAttachUtils.ShowError("ReAttach failed.", "Process not started.");
+                        break;
+                    case ReAttachResult.Cancelled:
+                        break;
+                    case ReAttachResult.Failed:
+                        ReAttachUtils.ShowError("ReAttach failed.", "Failed reattaching to process.");
+                        break;
+                }
             }
         }
 
@@ -155,23 +162,36 @@ namespace ReAttach
             Update();
         }
 
-        private void TryBuildSolution()
+        private bool TryBuildSolution()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            bool result = ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var dte = await _package.GetServiceAsync(typeof(SDTE)) as DTE2;
                 if (dte == null)
                 {
                     ReAttachUtils.ShowError("ReAttach failed", "Unable to rebuild solution before build.");
-                    return;
+                    return false;
                 }
                 try
                 {
-                    dte.Solution.SolutionBuild.Build(true);
+                    dte.Solution.SolutionBuild.Build(WaitForBuildToFinish: true);
+                    var numberOfProjectsThatFailedToBuild = dte.Solution.SolutionBuild.LastBuildInfo;
+
+                    if (numberOfProjectsThatFailedToBuild > 0)
+                    {
+                        ReAttachUtils.ShowError("ReAttach failed", $"{numberOfProjectsThatFailedToBuild} project{(numberOfProjectsThatFailedToBuild > 1 ? "s" : string.Empty)} failed to build before ReAttaching.{Environment.NewLine}{Environment.NewLine}See Build output window for more details.");
+                    }
+
+                    return numberOfProjectsThatFailedToBuild == 0;
                 }
-                catch (Exception) { }
+                catch (Exception) 
+                {
+                    return false;
+                }
             });
+
+            return result;
         }
 
         private bool EnsureDebuggerService()

--- a/ReAttach/Services/ReAttachUi.cs
+++ b/ReAttach/Services/ReAttachUi.cs
@@ -108,14 +108,16 @@ namespace ReAttach
             if (target == null)
                 return;
 
-            bool? buildSuccessful = null;
+            var buildSuccessful = false;
             if (_options.BuildBeforeReAttach)
             {
                 buildSuccessful = TryBuildSolution();
             }
 
-            //only ReAttach if the build has run before and was successful
-            if ((buildSuccessful ?? false) == true)
+            //Only ReAttach if
+            //a) option BuildBeforeReAttach is disabled or
+            //b) option BuildBeforeReAttach is enabled and the build has completed successfully with zero projects failing to build.
+            if (!_options.BuildBeforeReAttach || (_options.BuildBeforeReAttach && buildSuccessful))
             {
                 if (!EnsureDebuggerService())
                 {


### PR DESCRIPTION
Fixes: #27 

Once the build has completed it now checks the `LastBuildInfo` which is an `int` and represents how many projects failed to build.

If the value of `LastBuildInfo > 0` then it shows an error message and directs the user to check the Build output window for more details. 

If the build fails then the ReAttach won't attempt to start.